### PR TITLE
Understand dependencies from contracts-as-types without assignment

### DIFF
--- a/solcast/dependencies.py
+++ b/solcast/dependencies.py
@@ -33,12 +33,9 @@ def set_dependencies(source_nodes):
 
         # imported contracts used as types in assignment
         for node in contract.children(filters={"nodeType": "UserDefinedTypeName"}):
-            try:
-                ref_node = symbol_map[node.referencedDeclaration]
-                contract.dependencies.add(ref_node)
-            except KeyError:
-                # not all UserDefinedTypeName nodes are external dependencies
-                continue
+            ref_id = node.referencedDeclaration
+            if ref_id in symbol_map:
+                contract.dependencies.add(symbol_map[ref_id])
 
         # imported contracts as types, no assignment
         for node in contract.children(


### PR DESCRIPTION
### What I did
Understand dependencies when a externally imported contract type is used without assignment, e.g.:

```solidity
pragma solidity ^0.6.12;

import "./IERC20.sol";

contract Test2 {
    function t(address a, uint256 x) public {
        IERC20(a).transfer(a, x);
    }
}
```
Related: https://github.com/eth-brownie/brownie/pull/914

### How I did it
Added another filter within `set_dependencies`.

### How to verify it
Run tests.
